### PR TITLE
remove override e7e7e7 color for submenu links in small screens

### DIFF
--- a/lib/features/reps_core/reps_core.features.user_permission.inc
+++ b/lib/features/reps_core/reps_core.features.user_permission.inc
@@ -1066,6 +1066,8 @@ function reps_core_user_default_permissions() {
     'name' => 'bypass rh_node',
     'roles' => array(
       'administrator' => 'administrator',
+      'REPS Administrator' => 'REPS Administrator',
+      'editor' => 'editor',
     ),
     'module' => 'rabbit_hole',
   );

--- a/lib/themes/reps/css/reps.css
+++ b/lib/themes/reps/css/reps.css
@@ -39,7 +39,7 @@
 .smallScreensMenu ul li a:hover,
 .smallScreensMenu ul li a:focus {
   background: #0065a2 !important;
-  color: #aaaaaa !important;
+  color: #fff !important;
 }
 .readMoreLinkStyle {
   font-weight: bold;
@@ -1978,7 +1978,7 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   #main-menu ul li a:hover,
   #main-menu ul li a:focus {
     background: #0065a2 !important;
-    color: #aaaaaa !important;
+    color: #fff !important;
   }
   #main-menu .visible-sm,
   #main-menu .visible-xs {
@@ -2074,6 +2074,12 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
     padding: 5px 10px !important;
     font-size: 105%;
     color: #036 !important;
+  }
+  #main-menu .visible-sm ul li.active-trail.open ul li a:focus,
+  #main-menu .visible-xs ul li.active-trail.open ul li a:focus,
+  #main-menu .visible-sm ul li.active-trail.open ul li a:active,
+  #main-menu .visible-xs ul li.active-trail.open ul li a:active {
+    text-decoration: underline;
   }
   #main-menu .visible-sm ul li.active-trail.dropdown.open li,
   #main-menu .visible-xs ul li.active-trail.dropdown.open li {
@@ -2200,7 +2206,7 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   #main-menu ul li a:hover,
   #main-menu ul li a:focus {
     background: #0065a2 !important;
-    color: #aaaaaa !important;
+    color: #fff !important;
   }
   #main-menu .visible-ex1 ul li.first {
     display: none;

--- a/lib/themes/reps/css/reps.css
+++ b/lib/themes/reps/css/reps.css
@@ -1442,7 +1442,16 @@ form .field-name-field-reps-core-image {
 /* Tabs */
 dl.ckeditor-tabber dt {
   background: #f3f6f9;
-  border-color: #cccccc;
+  border-color: #ccc;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  align-items: center;
+}
+dl.ckeditor-tabber dt a {
+  width: 100%;
+  text-align: center;
 }
 dl.ckeditor-tabber dt.current {
   background: #fff !important;
@@ -1458,7 +1467,7 @@ dl.ckeditor-tabber dt:hover a {
   color: #fff;
 }
 dl.ckeditor-tabber dd {
-  border-color: #cccccc;
+  border-color: #ccc;
 }
 .quicktabs-wrapper {
   margin: 1em 0px;

--- a/lib/themes/reps/css/reps.css
+++ b/lib/themes/reps/css/reps.css
@@ -87,8 +87,8 @@ body.reps {
   font-family: Verdana, Arial, Helvetica, 'DejaVu Sans', sans-serif;
   color: #000000;
   line-height: 1.5;
-  background: #ffffff !important;
-  background-color: #ffffff !important;
+  background: #fff !important;
+  background-color: #fff !important;
   position: relative;
   filter: none;
 }
@@ -125,21 +125,21 @@ body.reps #mainContainer .region-featured-wrapper button#menu-button {
   margin: 5px 0 5px 15px;
   border-radius: 0;
   padding: 5px 10px;
-  color: #ffffff;
+  color: #fff;
   background: #074a8b;
   border: 1px solid #69c;
   font-size: 115%;
 }
 body.reps #mainContainer .region-featured-wrapper .home-button a,
 body.reps #mainContainer .region-featured-wrapper button#menu-button a {
-  color: #ffffff;
+  color: #fff;
 }
 body.reps #mainContainer .region-featured-wrapper .home-button:hover,
 body.reps #mainContainer .region-featured-wrapper .home-button:focus,
 body.reps #mainContainer .region-featured-wrapper button#menu-button:hover,
 body.reps #mainContainer .region-featured-wrapper button#menu-button:focus,
 body.reps #mainContainer .region-featured-wrapper button#menu-button.menu-open {
-  background: #ffffff;
+  background: #fff;
   color: #000000;
   border: 1px solid #000000;
   text-decoration: none;
@@ -195,7 +195,7 @@ body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container 
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li a.active,
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li a:hover,
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li a:focus {
-  color: #ffffff;
+  color: #fff;
   background: #b60522;
 }
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail a {
@@ -1443,21 +1443,10 @@ form .field-name-field-reps-core-image {
 dl.ckeditor-tabber dt {
   background: #f3f6f9;
   border-color: #cccccc;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: -webkit-flex;
-  display: flex;
-  align-items: center;
 }
-
-dl.ckeditor-tabber dt a {
-  width: 100%;
-  text-align: center;
-}
-
 dl.ckeditor-tabber dt.current {
-  background: #ffffff !important;
-  border-bottom-color: #ffffff;
+  background: #fff !important;
+  border-bottom-color: #fff;
 }
 dl.ckeditor-tabber dt.current a {
   color: #0065a2 !important;
@@ -1466,7 +1455,7 @@ dl.ckeditor-tabber dt:hover {
   background: #b60522;
 }
 dl.ckeditor-tabber dt:hover a {
-  color: #ffffff;
+  color: #fff;
 }
 dl.ckeditor-tabber dd {
   border-color: #cccccc;
@@ -1744,7 +1733,7 @@ p.top-button a {
   padding: 8px 50px 8px 50px;
   display: block;
   border-radius: 4px;
-  color: #ffffff;
+  color: #fff;
   transition: none;
 }
 p.top-button a:hover {
@@ -2002,7 +1991,7 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   #main-menu .visible-sm ul li.active-trail,
   #main-menu .visible-xs ul li.active-trail {
     display: block;
-    background: #ffffff;
+    background: #fff;
     margin: 0 !important;
   }
   #main-menu .visible-sm ul li.active-trail a,
@@ -2061,13 +2050,13 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   }
   #main-menu .visible-sm ul li.active-trail.open ul,
   #main-menu .visible-xs ul li.active-trail.open ul {
-    background: #ffffff !important;
+    background: #fff !important;
   }
   #main-menu .visible-sm ul li.active-trail.open ul li,
   #main-menu .visible-xs ul li.active-trail.open ul li {
     display: block !important;
     clear: both;
-    background: #ffffff !important;
+    background: #fff !important;
     margin: 0 !important;
     width: 100% !important;
   }
@@ -2076,11 +2065,6 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
     padding: 5px 10px !important;
     font-size: 105%;
     color: #036 !important;
-  }
-  #main-menu .visible-sm ul li.active-trail.open ul li a:hover,
-  #main-menu .visible-xs ul li.active-trail.open ul li a:hover {
-    background: #036 !important;
-    color: #ffffff !important;
   }
   #main-menu .visible-sm ul li.active-trail.dropdown.open li,
   #main-menu .visible-xs ul li.active-trail.dropdown.open li {
@@ -2196,7 +2180,11 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   #main-menu ul li {
     border-bottom: 1px solid #cce2ed;
   }
-
+  #main-menu ul li a {
+    color: #003366 !important;
+    background: none !important;
+    padding: 7px 10px !important;
+  }
   #main-menu ul li a.active {
     font-weight: bold;
   }
@@ -2240,11 +2228,4 @@ div[about*='news/videos'] .field-name-body {
 }
 .wtPopup.ttip_modal .wtPopupContent .ttip_content:last-child {
   padding-bottom: 20px;
-}
-
-/*REPR-1754 Spain - pop up display problem*/
-.wtPopup.ttip_modal .wtPopupContent {
-  padding: 0 20px;
-  max-height: 92%;
-  overflow: auto;
 }

--- a/lib/themes/reps/css/reps.css
+++ b/lib/themes/reps/css/reps.css
@@ -220,15 +220,14 @@ body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container 
 }
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail ul li a {
   border: none;
-  border-left: 1px solid #ffffff;
+  border-left: 1px solid #fff;
   background: none !important;
-  color: #e7e7e7 !important;
   margin: 0;
   padding: 0 10px 0;
 }
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail ul li a:hover,
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail ul li a:focus {
-  color: #ffffff;
+  color: #fff;
 }
 body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail ul li.first a {
   border-left: 0;
@@ -2197,11 +2196,7 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row 
   #main-menu ul li {
     border-bottom: 1px solid #cce2ed;
   }
-  #main-menu ul li a {
-    color: #003366 !important;
-    background: none !important;
-    padding: 7px 10px !important;
-  }
+
   #main-menu ul li a.active {
     font-weight: bold;
   }

--- a/lib/themes/reps/css/reps.css.less
+++ b/lib/themes/reps/css/reps.css.less
@@ -1642,7 +1642,17 @@ form .field-name-field-reps-core-image {
 dl.ckeditor-tabber {
   dt {
     background: #f3f6f9;
-    border-color: #cccccc;
+    border-color: #ccc;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    align-items: center;
+    
+    a {
+      width: 100%;
+      text-align: center;
+    }
   }
 
   dt.current {
@@ -1663,9 +1673,10 @@ dl.ckeditor-tabber {
   }
 
   dd {
-    border-color: #cccccc;
+    border-color: #ccc;
   }
 } // dl.ckeditor-tabber END
+
 .quicktabs-wrapper {
   margin: 1em 0px;
 
@@ -2554,6 +2565,7 @@ div[about*='news/videos'] {
 }
 
 /*REPR-1754 Spain - pop up display problem*/
+
 .wtPopup.ttip_modal .wtPopupContent {
   padding: 0 20px;
   max-height: 92%;

--- a/lib/themes/reps/css/reps.css.less
+++ b/lib/themes/reps/css/reps.css.less
@@ -101,7 +101,7 @@
       a:hover,
       a:focus {
         background: #0065a2 !important;
-        color: #aaaaaa !important;
+        color: #fff !important;
       }
     }
   }
@@ -2368,6 +2368,11 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row>
               padding: 5px 10px !important;
               font-size: 105%;
               color: #036 !important;
+              &:focus,
+              &:active {
+                text-decoration: underline;
+                
+              }
             }
           }
         }

--- a/lib/themes/reps/css/reps.css.less
+++ b/lib/themes/reps/css/reps.css.less
@@ -164,8 +164,8 @@ body.reps {
   font-family: Verdana, Arial, Helvetica, 'DejaVu Sans', sans-serif;
   color: #000000;
   line-height: 1.5;
-  background: #ffffff !important;
-  background-color: #ffffff !important;
+  background: #fff !important;
+  background-color: #fff !important;
   position: relative;
   filter: none;
 
@@ -207,13 +207,13 @@ body.reps {
         margin: 5px 0 5px 15px;
         border-radius: 0;
         padding: 5px 10px;
-        color: #ffffff;
+        color: #fff;
         background: #074a8b;
         border: 1px solid #69c;
         font-size: 115%;
 
         a {
-          color: #ffffff;
+          color: #fff;
         }
       } // .home-button END
       .home-button:hover,
@@ -221,7 +221,7 @@ body.reps {
       button#menu-button:hover,
       button#menu-button:focus,
       button#menu-button.menu-open {
-        background: #ffffff;
+        background: #fff;
         color: #000000;
         border: 1px solid #000000;
         text-decoration: none;
@@ -278,7 +278,7 @@ body.reps {
                 a.active,
                 a:hover,
                 a:focus {
-                  color: #ffffff;
+                  color: #fff;
                   background: @maltaRed;
                 }
               } // ul li END
@@ -306,16 +306,15 @@ body.reps {
 
                     a {
                       border: none;
-                      border-left: 1px solid #ffffff;
+                      border-left: 1px solid #fff;
                       background: none !important;
-                      color: #e7e7e7 !important;
                       margin: 0;
                       padding: 0 10px 0;
                     }
 
                     a:hover,
                     a:focus {
-                      color: #ffffff;
+                      color: #fff;
                     }
                   }
 
@@ -1647,8 +1646,8 @@ dl.ckeditor-tabber {
   }
 
   dt.current {
-    background: #ffffff !important;
-    border-bottom-color: #ffffff;
+    background: #fff !important;
+    border-bottom-color: #fff;
 
     a {
       color: #0065a2 !important;
@@ -1659,7 +1658,7 @@ dl.ckeditor-tabber {
     background: @maltaRed;
 
     a {
-      color: #ffffff;
+      color: #fff;
     }
   }
 
@@ -2013,7 +2012,7 @@ p.top-button a {
   padding: 8px 50px 8px 50px;
   display: block;
   border-radius: 4px;
-  color: #ffffff;
+  color: #fff;
   transition: none;
 }
 
@@ -2284,7 +2283,7 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row>
 
       ul li.active-trail {
         display: block;
-        background: #ffffff;
+        background: #fff;
         margin: 0 !important;
 
         a {
@@ -2345,12 +2344,12 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row>
         }
 
         ul {
-          background: #ffffff !important;
+          background: #fff !important;
 
           li {
             display: block !important;
             clear: both;
-            background: #ffffff !important;
+            background: #fff !important;
             margin: 0 !important;
             width: 100% !important;
 
@@ -2358,11 +2357,6 @@ body.reps #mainContainer #layout-body #block-views-reps-videos-block .views-row>
               padding: 5px 10px !important;
               font-size: 105%;
               color: #036 !important;
-            }
-
-            a:hover {
-              background: #036 !important;
-              color: #ffffff !important;
             }
           }
         }


### PR DESCRIPTION
body.reps #mainContainer .region-featured-wrapper #main-menu .navbar .container div ul li.active-trail ul li a {
    border: none;
    border-left: 1px solid #ffffff;
    background: none !important;
    **color: #e7e7e7 !important;**
    margin: 0;
    padding: 0 10px 0;
}